### PR TITLE
Update CPU monitoring

### DIFF
--- a/cpu/CPU_demos.ipynb
+++ b/cpu/CPU_demos.ipynb
@@ -12,10 +12,19 @@
     "- an `exchanger` to dissipate the heat flow from `CPU`\n",
     "- a `controler` to decide the power level of the `fan` from the `CPU` temperature\n",
     "\n",
-    "<img src=\"images/AMD_heatsink_and_fan.jpg\" alt=\"drawing\" style=\"width:600px;\"/>\n",
+    "<img src=\"images/AMD_heatsink_and_fan.jpg\" alt=\"drawing\" style=\"width:600px;\"/>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33ba30d8",
+   "metadata": {},
+   "source": [
     "\n",
     "# Design\n",
     "- How to easily [design a product](notebooks/1-Steady-state_design.ipynb)\n",
+    "- Explore multiple designs with a [Design of Experiments](notebooks/12-DoE.ipynb)\n",
+    "\n",
     "\n",
     "# Simulation\n",
     "- Steady-state simulation\n",
@@ -42,10 +51,15 @@
     "- MRO assessments\n",
     "\n",
     "# Orthogonal toolbox\n",
-    "- Run a [Design of Experiments](notebooks/12-DoE.ipynb)\n",
     "- Uncertainties assessment using [Montecarlo](notebooks/13-Montecarlo.ipynb)\n",
     "- solver [debugging capabilities](notebooks/14-Solver_debugging.ipynb)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bd3861f0",
+   "metadata": {},
+   "source": []
   }
  ],
  "metadata": {

--- a/cpu/notebooks/15-Parametric_geometry.ipynb
+++ b/cpu/notebooks/15-Parametric_geometry.ipynb
@@ -200,7 +200,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/cpu/notebooks/16-Monitoring_notebook.ipynb
+++ b/cpu/notebooks/16-Monitoring_notebook.ipynb
@@ -1,145 +1,131 @@
 {
-    "cells": [
-        {
-            "cell_type": "code",
-            "execution_count": 1,
-            "id": "dd7f94b2",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "from multiprocessing import Queue, Process\n",
-                "from cpu.utils.cpu_monitor_live import run_cpu_monitor, run_pipeline, run_spinners\n",
-                "from cpu.utils.monitor_simulation import run_simulation\n",
-                "import pandas as pd"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": 2,
-            "id": "40247965",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "# create a system model\n",
-                "from cpu.systems import CPUSystem\n",
-                "\n",
-                "cpu = CPUSystem(\"cpu\")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "ab992215",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "queue = Queue()\n",
-                "queue = Queue()\n",
-                "\n",
-                "sim_process = Process(target=run_simulation, args=(queue,))\n",
-                "sim_process.start()\n",
-                "sim_process = Process(target=run_simulation, args=(queue,))\n",
-                "sim_process.start()\n",
-                "\n",
-                "monitor_process = run_cpu_monitor(queue)\n",
-                "pipeline = [(run_spinners, (8, 60)), (run_spinners, (1, 60))]\n",
-                "run_pipeline(pipeline)\n",
-                "\n",
-                "monitor_process.join()\n",
-                "sim_process.join()\n",
-                "# Receive simulation results from the queue\n",
-                "if not queue.empty():\n",
-                "    results = queue.get()\n",
-                "    df = pd.DataFrame(results)\n",
-                "monitor_process.join()\n",
-                "sim_process.join()\n",
-                "# Receive simulation results from the queue\n",
-                "if not queue.empty():\n",
-                "    results = queue.get()\n",
-                "    df = pd.DataFrame(results)\n",
-                "\n",
-                "    # Save from notebook (safe path)\n",
-                "    df.to_csv(\"data/real_time_measure.csv\", index=False)\n",
-                "    print(\"Results saved!\")\n",
-                "else:\n",
-                "    print(\"Queue was empty. No results to save.\")\n"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "dfc87fa2",
-            "metadata": {},
-            "outputs": [],
-            "source": [
-                "#Differentiate the simulated and measured data\n",
-                "data_sim = pd.read_csv(\"data/real_time_measure.csv\")\n",
-                "data_mes = pd.read_csv(\"data/real_time_measure.csv\")\n",
-                "data_sim.rename(columns={'T_cpu_simulated': 'T_cpu'}, inplace=True)\n",
-                "data_mes.rename(columns={'T_cpu_measured': 'T_cpu'}, inplace=True)"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "8494d458",
-            "metadata": {},
-            "outputs": [
-                {
-                    "ename": "NameError",
-                    "evalue": "name 'data_mes' is not defined",
-                    "output_type": "error",
-                    "traceback": [
-                        "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-                        "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
-                        "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mcpu\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mutils\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mplot_recorders\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m plot_recorders\n\u001b[32m      3\u001b[39m plot_recorders(\n\u001b[32m      4\u001b[39m     {\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33moperation\u001b[39m\u001b[33m\"\u001b[39m: \u001b[43mdata_mes\u001b[49m,\n\u001b[32m      6\u001b[39m         \u001b[38;5;66;03m# \"simulation\": data_sim,\u001b[39;00m\n\u001b[32m      7\u001b[39m     },\n\u001b[32m      8\u001b[39m     [[(\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mT_cpu\u001b[39m\u001b[33m\"\u001b[39m), (\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mcpu.usage\u001b[39m\u001b[33m\"\u001b[39m)], [(\u001b[33m\"\u001b[39m\u001b[33mT_cpu\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mFan_rpm_1\u001b[39m\u001b[33m\"\u001b[39m), (\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mFan_rpm_1\u001b[39m\u001b[33m\"\u001b[39m)]],\n\u001b[32m      9\u001b[39m     width=\u001b[32m600\u001b[39m,\n\u001b[32m     10\u001b[39m     height=\u001b[32m350\u001b[39m,\n\u001b[32m     11\u001b[39m )\n",
-                        "\u001b[31mNameError\u001b[39m: name 'data_mes' is not defined"
-                    ]
-                }
-            ],
-            "source": [
-                "from cpu.utils.plot_recorders import plot_recorders\n",
-                "\n",
-                "plot_recorders(\n",
-                "    {\n",
-                "        \"operation\": data_mes,\n",
-                "        # \"simulation\": data_sim,\n",
-                "    },\n",
-                "    [[(\"time\", \"T_cpu\"), (\"time\", \"cpu.usage\")], [(\"T_cpu\", \"Fan_rpm_1\"), (\"time\", \"Fan_rpm_1\")]],\n",
-                "    width=600,\n",
-                "    height=350,\n",
-                ")"
-            ]
-        },
-        {
-            "cell_type": "code",
-            "execution_count": null,
-            "id": "f2ef8a1c",
-            "metadata": {},
-            "outputs": [],
-            "source": []
-        }
-    ],
-    "metadata": {
-        "kernelspec": {
-            "display_name": "Python 3",
-            "language": "python",
-            "name": "python3"
-        },
-        "language_info": {
-            "codemirror_mode": {
-                "name": "ipython",
-                "version": 3
-            },
-            "file_extension": ".py",
-            "mimetype": "text/x-python",
-            "name": "python",
-            "nbconvert_exporter": "python",
-            "pygments_lexer": "ipython3",
-            "version": "3.12.10"
-        },
-        "toc-showcode": false
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd7f94b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from multiprocessing import Queue\n",
+    "from cpu.utils.cpu_monitor_live import run_cpu_monitor, run_pipeline, get_pipeline\n",
+    "from cpu.utils.monitor_simulation import run_cpu_simulation\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40247965",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a system model\n",
+    "from cpu.systems import CPUSystem\n",
+    "from cosapp.drivers import NonLinearSolver\n",
+    "\n",
+    "cpu = CPUSystem(\"cpu\")\n",
+    "cpu.add_driver(NonLinearSolver(\"solver\", max_iter=10, factor=1.0, tol=1e-6))\n",
+    "cpu[\"exchanger.h_adder\"] = 150\n",
+    "cpu[\"cpu.heat_capacity\"] = 100"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab992215",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set process pipeline\n",
+    "queue = Queue()\n",
+    "sequence = {\n",
+    "    \"step1\": {\"nprocs\": 8, \"duration\": 30},\n",
+    "    \"step2\": {\"nprocs\": 1, \"duration\": 30},\n",
+    "}\n",
+    "pipeline, duration = get_pipeline(sequence)\n",
+    "\n",
+    "# run pipeline\n",
+    "sim_process = run_cpu_simulation(queue, cpu, duration)\n",
+    "monitor_process = run_cpu_monitor(queue, duration)\n",
+    "run_pipeline(pipeline)\n",
+    "monitor_process.join()\n",
+    "sim_process.join()\n",
+    "\n",
+    "# Receive simulation results from the queue\n",
+    "if not queue.empty():\n",
+    "    results = pd.DataFrame(queue.get())\n",
+    "\n",
+    "    # Save from notebook (safe path)\n",
+    "    results.to_csv(\"data/real_time_measure.csv\", index=False)\n",
+    "    print(\"Results saved!\")\n",
+    "else:\n",
+    "    print(\"Queue was empty. No results to save.\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dfc87fa2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Differentiate the simulated and measured data\n",
+    "data_sim = pd.read_csv(\"data/real_time_measure.csv\")\n",
+    "data_mes = pd.read_csv(\"data/real_time_measure.csv\")\n",
+    "data_sim.rename(columns={\"T_cpu_simulated\": \"T_cpu\"}, inplace=True)\n",
+    "data_mes.rename(columns={\"T_cpu_measured\": \"T_cpu\"}, inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8494d458",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from cpu.utils.plot_recorders import plot_recorders\n",
+    "\n",
+    "plot_recorders(\n",
+    "    {\n",
+    "        \"operation\": data_mes,\n",
+    "        # \"simulation\": data_sim,\n",
+    "    },\n",
+    "    [[(\"time\", \"T_cpu\"), (\"time\", \"cpu.usage\")], [(\"T_cpu\", \"Fan_rpm_1\"), (\"time\", \"Fan_rpm_1\")]],\n",
+    "    width=600,\n",
+    "    height=350,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2ef8a1c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  },
+  "toc-showcode": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/cpu/notebooks/16-Monitoring_notebook.ipynb
+++ b/cpu/notebooks/16-Monitoring_notebook.ipynb
@@ -1,117 +1,145 @@
 {
- "cells": [
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dd7f94b2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from multiprocessing import Queue, Process\n",
-    "from cpu.utils.cpu_monitor_live import run_cpu_monitor, run_pipeline, run_spinners\n",
-    "from cpu.utils.monitor_simulation import run_simulation\n",
-    "import pandas as pd\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "40247965",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# create a system model\n",
-    "from cpu.systems import CPUSystem\n",
-    "cpu = CPUSystem(\"cpu\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ab992215",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "queue = Queue()\n",
-    "\n",
-    "sim_process = Process(target=run_simulation, args=(queue,))\n",
-    "sim_process.start()\n",
-    "\n",
-    "monitor_process = run_cpu_monitor(queue)\n",
-    "pipeline = [(run_spinners, (8, 60)), (run_spinners, (1, 60))]\n",
-    "run_pipeline(pipeline)\n",
-    "\n",
-    "monitor_process.join()\n",
-    "sim_process.join()\n",
-    "# Receive simulation results from the queue\n",
-    "if not queue.empty():\n",
-    "    results = queue.get()\n",
-    "    df = pd.DataFrame(results)\n",
-    "\n",
-    "    # Save from notebook (safe path)\n",
-    "    df.to_csv(\"data/real_time_measure.csv\", index=False)\n",
-    "    print(\"Results saved!\")\n",
-    "else:\n",
-    "    print(\"Queue was empty. No results to save.\")\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dfc87fa2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Differentiate the simulated and measured data\n",
-    "data_sim = pd.read_csv(\"data/real_time_measure.csv\")\n",
-    "data_mes = pd.read_csv(\"data/real_time_measure.csv\")\n",
-    "data_sim.rename(columns={'T_cpu_simulated': 'T_cpu'}, inplace=True)\n",
-    "data_mes.rename(columns={'T_cpu_measured': 'T_cpu'}, inplace=True)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8494d458",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from cpu.utils.plot_recorders import plot_recorders\n",
-    "plot_recorders(\n",
-    "    {\n",
-    "        \"operation\": data_mes,\n",
-    "        # \"simulation\": data_sim,\n",
-    "    },\n",
-    "    [\n",
-    "        [(\"time\", \"T_cpu\"),(\"time\", \"cpu.usage\")], \n",
-    "        [(\"T_cpu\", \"Fan_rpm_1\"),(\"time\", \"Fan_rpm_1\")]\n",
-    "    ],\n",
-    "    width=600,\n",
-    "    height=350\n",
-    ")"
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.12.10"
-  },
-  "toc-showcode": false
- },
- "nbformat": 4,
- "nbformat_minor": 5
+    "cells": [
+        {
+            "cell_type": "code",
+            "execution_count": 1,
+            "id": "dd7f94b2",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "from multiprocessing import Queue, Process\n",
+                "from cpu.utils.cpu_monitor_live import run_cpu_monitor, run_pipeline, run_spinners\n",
+                "from cpu.utils.monitor_simulation import run_simulation\n",
+                "import pandas as pd"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": 2,
+            "id": "40247965",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# create a system model\n",
+                "from cpu.systems import CPUSystem\n",
+                "\n",
+                "cpu = CPUSystem(\"cpu\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "ab992215",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "queue = Queue()\n",
+                "queue = Queue()\n",
+                "\n",
+                "sim_process = Process(target=run_simulation, args=(queue,))\n",
+                "sim_process.start()\n",
+                "sim_process = Process(target=run_simulation, args=(queue,))\n",
+                "sim_process.start()\n",
+                "\n",
+                "monitor_process = run_cpu_monitor(queue)\n",
+                "pipeline = [(run_spinners, (8, 60)), (run_spinners, (1, 60))]\n",
+                "run_pipeline(pipeline)\n",
+                "\n",
+                "monitor_process.join()\n",
+                "sim_process.join()\n",
+                "# Receive simulation results from the queue\n",
+                "if not queue.empty():\n",
+                "    results = queue.get()\n",
+                "    df = pd.DataFrame(results)\n",
+                "monitor_process.join()\n",
+                "sim_process.join()\n",
+                "# Receive simulation results from the queue\n",
+                "if not queue.empty():\n",
+                "    results = queue.get()\n",
+                "    df = pd.DataFrame(results)\n",
+                "\n",
+                "    # Save from notebook (safe path)\n",
+                "    df.to_csv(\"data/real_time_measure.csv\", index=False)\n",
+                "    print(\"Results saved!\")\n",
+                "else:\n",
+                "    print(\"Queue was empty. No results to save.\")\n"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "dfc87fa2",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "#Differentiate the simulated and measured data\n",
+                "data_sim = pd.read_csv(\"data/real_time_measure.csv\")\n",
+                "data_mes = pd.read_csv(\"data/real_time_measure.csv\")\n",
+                "data_sim.rename(columns={'T_cpu_simulated': 'T_cpu'}, inplace=True)\n",
+                "data_mes.rename(columns={'T_cpu_measured': 'T_cpu'}, inplace=True)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "8494d458",
+            "metadata": {},
+            "outputs": [
+                {
+                    "ename": "NameError",
+                    "evalue": "name 'data_mes' is not defined",
+                    "output_type": "error",
+                    "traceback": [
+                        "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+                        "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+                        "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[5]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[34;01mcpu\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mutils\u001b[39;00m\u001b[34;01m.\u001b[39;00m\u001b[34;01mplot_recorders\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;28;01mimport\u001b[39;00m plot_recorders\n\u001b[32m      3\u001b[39m plot_recorders(\n\u001b[32m      4\u001b[39m     {\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m         \u001b[33m\"\u001b[39m\u001b[33moperation\u001b[39m\u001b[33m\"\u001b[39m: \u001b[43mdata_mes\u001b[49m,\n\u001b[32m      6\u001b[39m         \u001b[38;5;66;03m# \"simulation\": data_sim,\u001b[39;00m\n\u001b[32m      7\u001b[39m     },\n\u001b[32m      8\u001b[39m     [[(\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mT_cpu\u001b[39m\u001b[33m\"\u001b[39m), (\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mcpu.usage\u001b[39m\u001b[33m\"\u001b[39m)], [(\u001b[33m\"\u001b[39m\u001b[33mT_cpu\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mFan_rpm_1\u001b[39m\u001b[33m\"\u001b[39m), (\u001b[33m\"\u001b[39m\u001b[33mtime\u001b[39m\u001b[33m\"\u001b[39m, \u001b[33m\"\u001b[39m\u001b[33mFan_rpm_1\u001b[39m\u001b[33m\"\u001b[39m)]],\n\u001b[32m      9\u001b[39m     width=\u001b[32m600\u001b[39m,\n\u001b[32m     10\u001b[39m     height=\u001b[32m350\u001b[39m,\n\u001b[32m     11\u001b[39m )\n",
+                        "\u001b[31mNameError\u001b[39m: name 'data_mes' is not defined"
+                    ]
+                }
+            ],
+            "source": [
+                "from cpu.utils.plot_recorders import plot_recorders\n",
+                "\n",
+                "plot_recorders(\n",
+                "    {\n",
+                "        \"operation\": data_mes,\n",
+                "        # \"simulation\": data_sim,\n",
+                "    },\n",
+                "    [[(\"time\", \"T_cpu\"), (\"time\", \"cpu.usage\")], [(\"T_cpu\", \"Fan_rpm_1\"), (\"time\", \"Fan_rpm_1\")]],\n",
+                "    width=600,\n",
+                "    height=350,\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f2ef8a1c",
+            "metadata": {},
+            "outputs": [],
+            "source": []
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "codemirror_mode": {
+                "name": "ipython",
+                "version": 3
+            },
+            "file_extension": ".py",
+            "mimetype": "text/x-python",
+            "name": "python",
+            "nbconvert_exporter": "python",
+            "pygments_lexer": "ipython3",
+            "version": "3.12.10"
+        },
+        "toc-showcode": false
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
 }

--- a/cpu/systems/heatexchanger.py
+++ b/cpu/systems/heatexchanger.py
@@ -14,18 +14,26 @@ class HeatExchanger(System):
         self.add_input(FluidPort, "fl_in")
         self.add_inward("T_cpu", 0.0, unit="degC", desc="CPU temperature")
         self.add_inward("surface", 0.01, unit="m**2", desc="Exchanger surface")
+        self.add_inward("thickness", 1e-2, unit="m", desc="Exchanger thickness")
+        self.add_inward("density", 1.2, unit="kg/m**3", desc="Exchanger thickness")
         self.add_inward(
-            "cp", 1004.0, unit="J/K/kg", desc="Heat capacity of air at constant pressure"
+            "cp", 1004.0, unit="J/(K*kg)", desc="Specific heat capacity of air at constant pressure"
         )
-        self.add_inward("h_natural", 10, unit="W/(K*m**2)", desc="Heat natural conductivity")
-        self.add_inward("h_forced", 100, unit="W/(K*m**2)", desc="Heat forced conductivity")
-        self.add_inward("h_adder", 0.0, unit="W/(K*m**2)", desc="Heat conductivity adder")
+        self.add_inward(
+            "h_natural", 10.0, unit="W/(K*m**2)", desc="Natural heat transfer coefficient"
+        )
+        self.add_inward(
+            "h_forced", 100.0, unit="W/(K*m**2)", desc="Forced heat transfer coefficient"
+        )
+        self.add_inward("h_adder", 0.0, unit="W/(K*m**2)", desc="Adder heat transfer coefficient")
         self.add_inward("max_mass_flow", 1.0, unit="kg/s", desc="Maximum air mass flow")
 
         # outputs
         self.add_output(FluidPort, "fl_out")
         self.add_outward("heat_flow", 0.0, unit="W", desc="Exchanger-to-air heat flow")
-        self.add_outward("h", 110.0, unit="W/(K*m**2)", desc="Heat conductivity")
+        self.add_outward("h", 100.0, unit="W/(K*m**2)", desc="Total heat transfer coefficient")
+
+        self.add_transient("heat", der="heat_flow")
 
     def compute(self):
         self.h = (
@@ -36,4 +44,5 @@ class HeatExchanger(System):
         self.heat_flow = self.h * (self.T_cpu - self.fl_in.T) * self.surface
 
         self.fl_out.mass_flow = self.fl_in.mass_flow
-        self.fl_out.T = self.fl_in.T + self.heat_flow / self.cp
+        mass = self.density * self.surface * self.thickness
+        self.fl_out.T = self.fl_in.T + self.heat / (self.cp * mass)

--- a/cpu/tests/test_monitoring_cpu.py
+++ b/cpu/tests/test_monitoring_cpu.py
@@ -1,0 +1,35 @@
+import pandas as pd
+from multiprocessing import Queue
+from cosapp.drivers import NonLinearSolver
+
+from cpu.utils.cpu_monitor_live import run_cpu_monitor, run_pipeline, get_pipeline
+from cpu.utils.monitor_simulation import run_cpu_simulation
+from cpu.systems import CPUSystem
+
+
+def test_cpu_monitoring():
+    # set CPU system
+    cpu = CPUSystem("cpu")
+    cpu.add_driver(NonLinearSolver("solver", max_iter=10, factor=1.0, tol=1e-6))
+    cpu["exchanger.h_adder"] = 150
+    cpu["cpu.heat_capacity"] = 100
+
+    # set process pipeline
+    queue = Queue()
+    sequence = {
+        "step1": {"nprocs": 8, "duration": 10},
+        "step2": {"nprocs": 1, "duration": 10},
+    }
+    pipeline, duration = get_pipeline(sequence)
+
+    # run pipeline
+    sim_process = run_cpu_simulation(queue, cpu, duration)
+    monitor_process = run_cpu_monitor(queue, duration)
+    run_pipeline(pipeline)
+    monitor_process.join()
+    sim_process.join()
+
+    # collect data
+    assert queue.empty() == False
+    results = pd.DataFrame(queue.get())
+    assert results.empty == False

--- a/cpu/utils/cpu_monitor_live.py
+++ b/cpu/utils/cpu_monitor_live.py
@@ -29,17 +29,20 @@ def run_pipeline(pipeline):
 
 
 def get_mac_temperature():
+    """Capture CPU temperature for Mac OS."""
     result = subprocess.run(["istats", "cpu", "--value-only"], capture_output=True, text=True)
     output = result.stdout.strip().replace("°C", "").strip()
     return float(output)
 
 
 def get_linux_temperature():
+    """Capture CPU temperature for Linux OS."""
     temps = psutil.sensors_temperatures()
     return temps["coretemp"][0].current
 
 
 def get_mac_fan_speed():
+    """Capture fan speed for Mac OS."""
     result_fan = subprocess.run(["istats", "fan", "--value-only"], capture_output=True, text=True)
     fan_output_lines = result_fan.stdout.strip().splitlines()
     fan_rpms = int(fan_output_lines[1].replace("RPM", "").strip())
@@ -47,6 +50,7 @@ def get_mac_fan_speed():
 
 
 def get_linux_fan_speed():
+    """Capture fan speed for Linux OS."""
     return psutil.sensors_fans().popitem()[1][0].current
 
 
@@ -90,6 +94,7 @@ def run_cpu_monitor(queue: Queue, duration: float):
 
 
 def get_pipeline(sequence):
+    """Prepare pipeline tasks from sequence dict."""
     pipeline = []
     total_duration = 0.0
     for step in sequence.values():

--- a/cpu/utils/cpu_monitor_live.py
+++ b/cpu/utils/cpu_monitor_live.py
@@ -22,64 +22,79 @@ def run_spinners(cpu_count: int, duration: float):
         process.join()
 
 
-def get_cpu_info(queue: Queue):
+def run_pipeline(pipeline):
+    """Run each step of pipeline."""
+    for func, args in pipeline:
+        func(*args)
+
+
+def get_mac_temperature():
+    result = subprocess.run(["istats", "cpu", "--value-only"], capture_output=True, text=True)
+    output = result.stdout.strip().replace("°C", "").strip()
+    return float(output)
+
+
+def get_linux_temperature():
+    temps = psutil.sensors_temperatures()
+    return temps["coretemp"][0].current
+
+
+def get_mac_fan_speed():
+    result_fan = subprocess.run(["istats", "fan", "--value-only"], capture_output=True, text=True)
+    fan_output_lines = result_fan.stdout.strip().splitlines()
+    fan_rpms = int(fan_output_lines[1].replace("RPM", "").strip())
+    return fan_rpms
+
+
+def get_linux_fan_speed():
+    return psutil.sensors_fans().popitem()[1][0].current
+
+
+def get_cpu_info(queue: Queue, duration: float):
     """Assess the platform and collect parameters from running CPU processors."""
     is_mac = platform.system() == "Darwin"
     is_linux = platform.system() == "Linux"
 
     t0 = time.time()
-    while time.time() - t0 < 90:
+    while time.time() < t0 + duration:
+        # get usage info
         usage = psutil.cpu_percent(interval=1)
 
-        if is_mac:
-            # Temperature via istats
-            try:
-                result = subprocess.run(
-                    ["istats", "cpu", "--value-only"], capture_output=True, text=True
-                )
-                output = result.stdout.strip().replace("°C", "").strip()
-                temp_val = float(output)
-            except ValueError:
-                temp_val = None
+        # get temperature info
+        try:
+            if is_mac:
+                temp_val = get_mac_temperature()
+            elif is_linux:
+                temp_val = get_linux_temperature()
+        except Exception:
+            temp_val = None
 
-            # Get fan RPMs via istats
-            try:
-                result_fan = subprocess.run(
-                    ["istats", "fan", "--value-only"], capture_output=True, text=True
-                )
-                fan_output_lines = result_fan.stdout.strip().splitlines()
-                fan_rpms = int(fan_output_lines[1].replace("RPM", "").strip())
-            except ValueError:
-                fan_rpms = None
-
-        elif is_linux:
-            # Temperature via ps_utils
-            try:
-                temps = psutil.sensors_temperatures()
-                temp_val = temps["coretemp"][0].current
-            except Exception:
-                temp_val = None
-
-            # Fan RPMs via ps_utils
-            try:
-                fan_rpms = psutil.sensors_fans().popitem()[1][0].current
-            except Exception:
-                fan_rpms = None
+        # get fan info
+        try:
+            if is_mac:
+                fan_rpms = get_mac_fan_speed()
+            elif is_linux:
+                fan_rpms = get_linux_fan_speed()
+        except Exception:
+            fan_rpms = None
 
         elapsed = round(time.time() - t0, 3)
         queue.put((elapsed, usage, temp_val, fan_rpms))
 
-    queue.put("DONE")
 
-
-def run_cpu_monitor(queue: Queue):
+def run_cpu_monitor(queue: Queue, duration: float):
     """Run CPU info collection process."""
-    process = Process(target=get_cpu_info, args=(queue,))
+    process = Process(target=get_cpu_info, args=(queue, duration))
     process.start()
     return process
 
 
-def run_pipeline(pipeline):
-    """Run each step of pipeline."""
-    for func, args in pipeline:
-        func(*args)
+def get_pipeline(sequence):
+    pipeline = []
+    total_duration = 0.0
+    for step in sequence.values():
+        nprocs = step["nprocs"]
+        duration = step["duration"]
+        pipeline.append((run_spinners, (nprocs, duration)))
+        total_duration += duration
+    return pipeline, total_duration

--- a/cpu/utils/display.py
+++ b/cpu/utils/display.py
@@ -2,26 +2,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ipywidgets as widgets
-from pyoccad.render import JupyterThreeJSRenderer, JupyterThreeJSRenderer2d
 
 
-def render_view(shape, size=(600, 600), position=(-1.0, 0, 0), view_2D=False):
-    view_obj = JupyterThreeJSRenderer2d if view_2D else JupyterThreeJSRenderer
-    render = view_obj(view_size=size, camera_target=(1.0, 0.0, 0.0), camera_position=position)
-    render_row = render.add_shape(
-        shape, uid="blade", face_color="#156289", opacity=1.0, plot_edges=False
-    )
-    return render, render_row
-
-
-def compare_with_image(s):
+def compare_with_image(s, render2d, render):
     """Compare with image."""
     file = open("../images/fan.png", "rb")
     image = file.read()
-    img = widgets.Image(value=image, format="png", width=600, height=600)
-
-    render, _ = render_view(s.geometry.shape)
-    render2d, _ = render_view(s.geometry.shape, view_2D=True)
+    img = widgets.Image(
+        value=image,
+        format="png",
+        width=600,
+        height=600,
+    )
 
     blade_slider = widgets.IntSlider(
         value=7,

--- a/cpu/utils/display.py
+++ b/cpu/utils/display.py
@@ -2,18 +2,26 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import ipywidgets as widgets
+from pyoccad.render import JupyterThreeJSRenderer, JupyterThreeJSRenderer2d
 
 
-def compare_with_image(s, render2d, render):
+def render_view(shape, size=(600, 600), position=(-1.0, 0, 0), view_2D=False):
+    view_obj = JupyterThreeJSRenderer2d if view_2D else JupyterThreeJSRenderer
+    render = view_obj(view_size=size, camera_target=(1.0, 0.0, 0.0), camera_position=position)
+    render_row = render.add_shape(
+        shape, uid="blade", face_color="#156289", opacity=1.0, plot_edges=False
+    )
+    return render, render_row
+
+
+def compare_with_image(s):
     """Compare with image."""
     file = open("../images/fan.png", "rb")
     image = file.read()
-    img = widgets.Image(
-        value=image,
-        format="png",
-        width=600,
-        height=600,
-    )
+    img = widgets.Image(value=image, format="png", width=600, height=600)
+
+    render, _ = render_view(s.geometry.shape)
+    render2d, _ = render_view(s.geometry.shape, view_2D=True)
 
     blade_slider = widgets.IntSlider(
         value=7,

--- a/cpu/utils/monitor_simulation.py
+++ b/cpu/utils/monitor_simulation.py
@@ -1,22 +1,22 @@
-from cosapp.drivers import NonLinearSolver
+from multiprocessing import Process
+import time
 
-from cpu.systems import CPUSystem
+
+def run_cpu_simulation(queue, cpu, duration):
+    process = Process(target=run_simulation, args=(queue, cpu, duration))
+    process.start()
+    return process
 
 
-def run_simulation(queue):
+def run_simulation(queue, cpu, duration):
     """Run simulation at each time step collecting live CPU data."""
-    cpu = CPUSystem("cpu")
-    cpu.add_driver(NonLinearSolver("solver", max_iter=10, factor=1.0, tol=1e-6))
-    cpu["exchanger.h_adder"] = 150
-    cpu["cpu.heat_capacity"] = 100
 
     simulation_results = []
     i = 0
     simulated_T = 0.0
-    while True:
+    t0 = time.time()
+    while time.time() < t0 + duration:
         data = queue.get()
-        if data == "DONE":
-            break
 
         # prepare and run simu
         t, usage, measured_T, fan_rpms = data

--- a/cpu/utils/monitor_simulation.py
+++ b/cpu/utils/monitor_simulation.py
@@ -1,8 +1,9 @@
-from multiprocessing import Process
 import time
+from multiprocessing import Process
 
 
 def run_cpu_simulation(queue, cpu, duration):
+    """Run global simulation as process."""
     process = Process(target=run_simulation, args=(queue, cpu, duration))
     process.start()
     return process

--- a/cpu/utils/plot_recorders.py
+++ b/cpu/utils/plot_recorders.py
@@ -5,31 +5,38 @@ import ipywidgets
 import plotly.graph_objs as go
 
 
-def plot_recorders(recs, pplots, *args, **kwargs):
+def plot_recorders(recs, pplots, title="", **kwargs):
     """plot_recorders."""
     plots = []
+    vsize = len(pplots)
+    hsize = len(pplots[0])
+    width = 300 * hsize
+    height = 400 * vsize
     for r in pplots:
         r_plots = []
         for p in r:
             x, y = p
+            x, xlabel = x.popitem() if isinstance(x, dict) else (x, x)
+            y, ylabel = y.popitem() if isinstance(y, dict) else (y, y)
 
             plot_options = dict(
-                width=1200,
-                height=400,
-                title={
-                    "text": "CPU simulation analysis",
-                    "font": {"size": 18},
-                    "x": 0.5,
+                width=width,
+                height=height,
+                xaxis={
+                    "title": {"text": f"{xlabel}", "font": {"size": 20}},
+                    "gridcolor": "#EBF0F8",
                 },
-                xaxis={"title": {"text": f"{x}", "font": {"size": 12}}, "gridcolor": "#EBF0F8"},
-                yaxis={"title": {"text": f"{y}", "font": {"size": 12}}, "gridcolor": "#EBF0F8"},
-                legend={
-                    "x": 0.35,
-                    "y": 0.25,
-                    "font": {"size": 8},
-                    "orientation": "h",
-                    "xanchor": "center",
+                yaxis={
+                    "title": {"text": f"{ylabel}", "font": {"size": 20}},
+                    "gridcolor": "#EBF0F8",
                 },
+                # legend={
+                #     "x": 0.35,
+                #     "y": 0.25,
+                #     "font": {"size": 20},
+                #     "orientation": "h",
+                #     "xanchor": "center",
+                # },
                 plot_bgcolor="white",
                 hovermode="x",
             )


### PR DESCRIPTION
Light refactoring of CPU monitoring. 

Proposed changes: 
- update `cpu_monitor_live.py` and `monitor_simulation.py` to be more flexible 
- handle the pipeline steps from a sequence dict more understandable 
- manage to find the OS type (only Mac and Linux for now) to catch CPU temperature and fan speed 
- update notebooks `16-Monitoring_notebook.ipynb` 
- add test 

- [x] tests passed
- [x] precommit passed 